### PR TITLE
Make sure parser doesnt crash on trailing lt

### DIFF
--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -299,7 +299,7 @@ function parseContent(window, input) {
       return result;
     }
 
-    var m = input.match(/^([^<]*)(<[^>]+>?)?/);
+    var m = input.match(/^([^<]*)(<[^>]*>?)?/);
     // If there is some text before the next tag, return it, otherwise return
     // the tag.
     return consume(m[1] ? m[1] : m[2]);

--- a/tests/integration/cue-content.vtt
+++ b/tests/integration/cue-content.vtt
@@ -2,4 +2,4 @@ WEBVTT
 
 00:32.500 --> 00:33.500 align:start size:50% line:40% region:escapes
 <v Neil deGrasse Tyson><i>Laughs</i> &am&amp; other <i> stuff &gt; &l&lt;&rl&rlm;&lrm; </i>
-Oh my! &gt;
+Oh my! &gt;<removed tag><


### PR DESCRIPTION
If a cue ends with just an opening <, the regex in the parseContent method doesnt find neither preceding text nor an actual tag, and just crashes in the consume method.

This makes sure cues like "bla bla<" result in "bla bla" text displayed, just as would be the case for "bla bla<mytag".

ref videojs#18