### PR TITLE
Remove IE8 support

### DIFF
--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -625,8 +625,6 @@ CueStyleBox.prototype.constructor = CueStyleBox;
 // compute things with such as if it overlaps or intersects with another Element.
 // Can initialize it with either a StyleBox or another BoxPosition.
 function BoxPosition(obj) {
-  var isIE8 = (/MSIE\s8\.0/).test(navigator.userAgent);
-
   // Either a BoxPosition was passed in and we need to copy it, or a StyleBox
   // was passed in and we need to copy the results of 'getBoundingClientRect'
   // as the object returned is readonly. All co-ordinate values are in reference
@@ -655,10 +653,6 @@ function BoxPosition(obj) {
   this.bottom = obj.bottom || (top + (obj.height || height));
   this.width = obj.width || width;
   this.lineHeight = lh !== undefined ? lh : obj.lineHeight;
-
-  if (isIE8 && !this.lineHeight) {
-    this.lineHeight = 13;
-  }
 }
 
 // Move the box along a particular axis. Optionally pass in an amount to move

--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -531,15 +531,6 @@ StyleBox.prototype.formatStyle = function(val, unit) {
 // Constructs the computed display state of the cue (a div). Places the div
 // into the overlay which should be a block level element (usually a div).
 function CueStyleBox(window, cue, styleOptions) {
-  var isIE8 = (/MSIE\s8\.0/).test(navigator.userAgent);
-  var color = "rgba(255, 255, 255, 1)";
-  var backgroundColor = "rgba(0, 0, 0, 0.8)";
-
-  if (isIE8) {
-    color = "rgb(255, 255, 255)";
-    backgroundColor = "rgb(0, 0, 0)";
-  }
-
   StyleBox.call(this);
   this.cue = cue;
 
@@ -547,22 +538,20 @@ function CueStyleBox(window, cue, styleOptions) {
   // have inline positioning and will function as the cue background box.
   this.cueDiv = parseContent(window, cue.text);
   var styles = {
-    color: color,
-    backgroundColor: backgroundColor,
+    color: "rgba(255, 255, 255, 1)",
+    backgroundColor:  "rgba(0, 0, 0, 0.8)",
     position: "relative",
     left: 0,
     right: 0,
     top: 0,
     bottom: 0,
-    display: "inline"
+    display: "inline",
+    writingMode: cue.vertical === "" ? "horizontal-tb"
+                                     : cue.vertical === "lr" ? "vertical-lr"
+                                                             : "vertical-rl";
+    unicodeBidi: "plaintext";
   };
 
-  if (!isIE8) {
-    styles.writingMode = cue.vertical === "" ? "horizontal-tb"
-                                             : cue.vertical === "lr" ? "vertical-lr"
-                                                                     : "vertical-rl";
-    styles.unicodeBidi = "plaintext";
-  }
   this.applyStyles(styles, this.cueDiv);
 
   // Create an absolutely positioned div that will be used to position the cue
@@ -570,22 +559,18 @@ function CueStyleBox(window, cue, styleOptions) {
   // mirrors of them except "middle" which is "center" in CSS.
   this.div = window.document.createElement("div");
   styles = {
+    direction: determineBidi(this.cueDiv),
+    writingMode: cue.vertical === "" ? "horizontal-tb"
+                                     : cue.vertical === "lr" ? "vertical-lr"
+                                                             : "vertical-rl",
+    unicodeBidi: "plaintext",
     textAlign: cue.align === "middle" ? "center" : cue.align,
     font: styleOptions.font,
     whiteSpace: "pre-line",
     position: "absolute"
   };
 
-  if (!isIE8) {
-    styles.direction = determineBidi(this.cueDiv);
-    styles.writingMode = cue.vertical === "" ? "horizontal-tb"
-                                             : cue.vertical === "lr" ? "vertical-lr"
-                                                                     : "vertical-rl".
-    stylesunicodeBidi =  "plaintext";
-  }
-
   this.applyStyles(styles);
-
   this.div.appendChild(this.cueDiv);
 
   // Calculate the distance from the reference edge of the viewport to the text

--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -548,8 +548,8 @@ function CueStyleBox(window, cue, styleOptions) {
     display: "inline",
     writingMode: cue.vertical === "" ? "horizontal-tb"
                                      : cue.vertical === "lr" ? "vertical-lr"
-                                                             : "vertical-rl";
-    unicodeBidi: "plaintext";
+                                                             : "vertical-rl",
+    unicodeBidi: "plaintext"
   };
 
   this.applyStyles(styles, this.cueDiv);

--- a/lib/vttcue.js
+++ b/lib/vttcue.js
@@ -57,16 +57,6 @@ function extend(obj) {
 }
 
 function VTTCue(startTime, endTime, text) {
-  var cue = this;
-  var isIE8 = (/MSIE\s8\.0/).test(navigator.userAgent);
-  var baseObj = {};
-
-  if (isIE8) {
-    cue = document.createElement('custom');
-  } else {
-    baseObj.enumerable = true;
-  }
-
   /**
    * Shim implementation specific properties. These properties are not in
    * the spec.
@@ -75,7 +65,7 @@ function VTTCue(startTime, endTime, text) {
   // Lets us know when the VTTCue's data has changed in such a way that we need
   // to recompute its display state. This lets us compute its display state
   // lazily.
-  cue.hasBeenReset = false;
+  this.hasBeenReset = false;
 
   /**
    * VTTCue and TextTrackCue properties
@@ -97,28 +87,29 @@ function VTTCue(startTime, endTime, text) {
   var _size = 50;
   var _align = "middle";
 
-  Object.defineProperty(cue,
-    "id", extend({}, baseObj, {
+  Object.defineProperties(this, {
+    "id": {
+      enumerable: true,
       get: function() {
         return _id;
       },
       set: function(value) {
         _id = "" + value;
       }
-    }));
+    }),
 
-  Object.defineProperty(cue,
-    "pauseOnExit", extend({}, baseObj, {
+    "pauseOnExit": {
+      enumerable: true,
       get: function() {
         return _pauseOnExit;
       },
       set: function(value) {
         _pauseOnExit = !!value;
       }
-    }));
+    }),
 
-  Object.defineProperty(cue,
-    "startTime", extend({}, baseObj, {
+    "startTime": {
+      enumerable: true,
       get: function() {
         return _startTime;
       },
@@ -129,10 +120,10 @@ function VTTCue(startTime, endTime, text) {
         _startTime = value;
         this.hasBeenReset = true;
       }
-    }));
+    }),
 
-  Object.defineProperty(cue,
-    "endTime", extend({}, baseObj, {
+    "endTime": {
+      enumerable: true,
       get: function() {
         return _endTime;
       },
@@ -143,10 +134,10 @@ function VTTCue(startTime, endTime, text) {
         _endTime = value;
         this.hasBeenReset = true;
       }
-    }));
+    }),
 
-  Object.defineProperty(cue,
-    "text", extend({}, baseObj, {
+    "text": {
+      enumerable: true,
       get: function() {
         return _text;
       },
@@ -154,10 +145,10 @@ function VTTCue(startTime, endTime, text) {
         _text = "" + value;
         this.hasBeenReset = true;
       }
-    }));
+    })
 
-  Object.defineProperty(cue,
-    "region", extend({}, baseObj, {
+    "region": {
+      enumerable: true,
       get: function() {
         return _region;
       },
@@ -165,10 +156,10 @@ function VTTCue(startTime, endTime, text) {
         _region = value;
         this.hasBeenReset = true;
       }
-    }));
+    }),
 
-  Object.defineProperty(cue,
-    "vertical", extend({}, baseObj, {
+    "vertical": {
+      enumerable: true,
       get: function() {
         return _vertical;
       },
@@ -181,10 +172,10 @@ function VTTCue(startTime, endTime, text) {
         _vertical = setting;
         this.hasBeenReset = true;
       }
-    }));
+    }),
 
-  Object.defineProperty(cue,
-    "snapToLines", extend({}, baseObj, {
+    "snapToLines": {
+      enumerable: true,
       get: function() {
         return _snapToLines;
       },
@@ -192,10 +183,10 @@ function VTTCue(startTime, endTime, text) {
         _snapToLines = !!value;
         this.hasBeenReset = true;
       }
-    }));
+    }),
 
-  Object.defineProperty(cue,
-    "line", extend({}, baseObj, {
+    "line": {
+      enumerable: true,
       get: function() {
         return _line;
       },
@@ -206,10 +197,10 @@ function VTTCue(startTime, endTime, text) {
         _line = value;
         this.hasBeenReset = true;
       }
-    }));
+    }),
 
-  Object.defineProperty(cue,
-    "lineAlign", extend({}, baseObj, {
+    "lineAlign": {
+      enumerable: true,
       get: function() {
         return _lineAlign;
       },
@@ -221,10 +212,10 @@ function VTTCue(startTime, endTime, text) {
         _lineAlign = setting;
         this.hasBeenReset = true;
       }
-    }));
+    }),
 
-  Object.defineProperty(cue,
-    "position", extend({}, baseObj, {
+    "position": {
+      enumerable: true,
       get: function() {
         return _position;
       },
@@ -235,10 +226,10 @@ function VTTCue(startTime, endTime, text) {
         _position = value;
         this.hasBeenReset = true;
       }
-    }));
+    }),
 
-  Object.defineProperty(cue,
-    "positionAlign", extend({}, baseObj, {
+    "positionAlign": {
+      enumerable: true,
       get: function() {
         return _positionAlign;
       },
@@ -250,10 +241,10 @@ function VTTCue(startTime, endTime, text) {
         _positionAlign = setting;
         this.hasBeenReset = true;
       }
-    }));
+    }),
 
-  Object.defineProperty(cue,
-    "size", extend({}, baseObj, {
+    "size": {
+      enumerable: true,
       get: function() {
         return _size;
       },
@@ -264,10 +255,10 @@ function VTTCue(startTime, endTime, text) {
         _size = value;
         this.hasBeenReset = true;
       }
-    }));
+    }),
 
-  Object.defineProperty(cue,
-    "align", extend({}, baseObj, {
+    "align": {
+      enumerable: true,
       get: function() {
         return _align;
       },
@@ -279,18 +270,15 @@ function VTTCue(startTime, endTime, text) {
         _align = setting;
         this.hasBeenReset = true;
       }
-    }));
+    })
+  });
 
   /**
    * Other <track> spec defined properties
    */
 
   // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#text-track-cue-display-state
-  cue.displayState = undefined;
-
-  if (isIE8) {
-    return cue;
-  }
+  this.displayState = undefined;
 }
 
 /**

--- a/lib/vttcue.js
+++ b/lib/vttcue.js
@@ -44,18 +44,6 @@ function findAlignSetting(value) {
   return align ? value.toLowerCase() : false;
 }
 
-function extend(obj) {
-  var i = 1;
-  for (; i < arguments.length; i++) {
-    var cobj = arguments[i];
-    for (var p in cobj) {
-      obj[p] = cobj[p];
-    }
-  }
-
-  return obj;
-}
-
 function VTTCue(startTime, endTime, text) {
   /**
    * Shim implementation specific properties. These properties are not in

--- a/lib/vttcue.js
+++ b/lib/vttcue.js
@@ -16,16 +16,16 @@
 
 var autoKeyword = "auto";
 var directionSetting = {
-  "": true,
-  "lr": true,
-  "rl": true
+  "": 1,
+  "lr": 1,
+  "rl": 1
 };
 var alignSetting = {
-  "start": true,
-  "middle": true,
-  "end": true,
-  "left": true,
-  "right": true
+  "start": 1,
+  "middle": 1,
+  "end": 1,
+  "left": 1,
+  "right": 1
 };
 
 function findDirectionSetting(value) {

--- a/lib/vttcue.js
+++ b/lib/vttcue.js
@@ -96,7 +96,7 @@ function VTTCue(startTime, endTime, text) {
       set: function(value) {
         _id = "" + value;
       }
-    }),
+    },
 
     "pauseOnExit": {
       enumerable: true,
@@ -106,7 +106,7 @@ function VTTCue(startTime, endTime, text) {
       set: function(value) {
         _pauseOnExit = !!value;
       }
-    }),
+    },
 
     "startTime": {
       enumerable: true,
@@ -120,7 +120,7 @@ function VTTCue(startTime, endTime, text) {
         _startTime = value;
         this.hasBeenReset = true;
       }
-    }),
+    },
 
     "endTime": {
       enumerable: true,
@@ -134,7 +134,7 @@ function VTTCue(startTime, endTime, text) {
         _endTime = value;
         this.hasBeenReset = true;
       }
-    }),
+    },
 
     "text": {
       enumerable: true,
@@ -145,7 +145,7 @@ function VTTCue(startTime, endTime, text) {
         _text = "" + value;
         this.hasBeenReset = true;
       }
-    })
+    },
 
     "region": {
       enumerable: true,
@@ -156,7 +156,7 @@ function VTTCue(startTime, endTime, text) {
         _region = value;
         this.hasBeenReset = true;
       }
-    }),
+    },
 
     "vertical": {
       enumerable: true,
@@ -172,7 +172,7 @@ function VTTCue(startTime, endTime, text) {
         _vertical = setting;
         this.hasBeenReset = true;
       }
-    }),
+    },
 
     "snapToLines": {
       enumerable: true,
@@ -183,7 +183,7 @@ function VTTCue(startTime, endTime, text) {
         _snapToLines = !!value;
         this.hasBeenReset = true;
       }
-    }),
+    },
 
     "line": {
       enumerable: true,
@@ -197,7 +197,7 @@ function VTTCue(startTime, endTime, text) {
         _line = value;
         this.hasBeenReset = true;
       }
-    }),
+    },
 
     "lineAlign": {
       enumerable: true,
@@ -212,7 +212,7 @@ function VTTCue(startTime, endTime, text) {
         _lineAlign = setting;
         this.hasBeenReset = true;
       }
-    }),
+    },
 
     "position": {
       enumerable: true,
@@ -226,7 +226,7 @@ function VTTCue(startTime, endTime, text) {
         _position = value;
         this.hasBeenReset = true;
       }
-    }),
+    },
 
     "positionAlign": {
       enumerable: true,
@@ -241,7 +241,7 @@ function VTTCue(startTime, endTime, text) {
         _positionAlign = setting;
         this.hasBeenReset = true;
       }
-    }),
+    },
 
     "size": {
       enumerable: true,
@@ -255,7 +255,7 @@ function VTTCue(startTime, endTime, text) {
         _size = value;
         this.hasBeenReset = true;
       }
-    }),
+    },
 
     "align": {
       enumerable: true,
@@ -270,7 +270,7 @@ function VTTCue(startTime, endTime, text) {
         _align = setting;
         this.hasBeenReset = true;
       }
-    })
+    }
   });
 
   /**


### PR DESCRIPTION
First introduced via https://github.com/mozilla/vtt.js/pull/337, removing just the main IE8 things like defineProperties->defineProperty, so, going back to defineProperties.