### PR TITLE
docs: update URLs in NPM package to point to videojs repo.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "main": "lib/browser-index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gkatsev/vtt.js.git"
+    "url": "https://github.com/videojs/vtt.js.git"
   },
-  "homepage": "https://github.com/gkatsev/vtt.js",
+  "homepage": "https://github.com/videojs/vtt.js",
   "devDependencies": {
     "async": "0.9.0",
     "browserify": "^14.3.0",
@@ -56,10 +56,7 @@
     "minify": "grunt uglify:dist uglify:global",
     "test": "grunt"
   },
-  "license": {
-    "type": "Apache-2.0",
-    "url": "https://github.com/gkatsev/vtt.js/blob/master/LICENSE"
-  },
+  "license": "Apache-2.0",
   "dependencies": {
     "global": "^4.3.1"
   }


### PR DESCRIPTION
@gkatsev is there any issue about updating the URLs to point to this (videojs) repo as the canonical home of videojs-vtt.js? Does it cause any problems with NPM?