### PR TITLE
Fix: improve error messages in vttcue.js and vttregion.js

### DIFF
--- a/lib/vttcue.js
+++ b/lib/vttcue.js
@@ -155,7 +155,7 @@ function VTTCue(startTime, endTime, text) {
         var setting = findDirectionSetting(value);
         // Have to check for false because the setting an be an empty string.
         if (setting === false) {
-          throw new SyntaxError("An invalid or illegal string was specified.");
+          throw new SyntaxError("Vertical: an invalid or illegal direction string was specified.");
         }
         _vertical = setting;
         this.hasBeenReset = true;
@@ -180,7 +180,7 @@ function VTTCue(startTime, endTime, text) {
       },
       set: function(value) {
         if (typeof value !== "number" && value !== autoKeyword) {
-          throw new SyntaxError("An invalid number or illegal string was specified.");
+          throw new SyntaxError("Line: an invalid number or illegal string was specified.");
         }
         _line = value;
         this.hasBeenReset = true;
@@ -195,7 +195,7 @@ function VTTCue(startTime, endTime, text) {
       set: function(value) {
         var setting = findAlignSetting(value);
         if (!setting) {
-          throw new SyntaxError("An invalid or illegal string was specified.");
+          throw new SyntaxError("lineAlign: an invalid or illegal alignment string was specified.");
         }
         _lineAlign = setting;
         this.hasBeenReset = true;
@@ -224,7 +224,7 @@ function VTTCue(startTime, endTime, text) {
       set: function(value) {
         var setting = findAlignSetting(value);
         if (!setting) {
-          throw new SyntaxError("An invalid or illegal string was specified.");
+          throw new SyntaxError("positionAlign: An invalid or illegal alignment string was specified.");
         }
         _positionAlign = setting;
         this.hasBeenReset = true;
@@ -253,7 +253,7 @@ function VTTCue(startTime, endTime, text) {
       set: function(value) {
         var setting = findAlignSetting(value);
         if (!setting) {
-          throw new SyntaxError("An invalid or illegal string was specified.");
+          throw new SyntaxError("align: An invalid or illegal alignment string was specified.");
         }
         _align = setting;
         this.hasBeenReset = true;

--- a/lib/vttregion.js
+++ b/lib/vttregion.js
@@ -123,7 +123,7 @@ function VTTRegion() {
         var setting = findScrollSetting(value);
         // Have to check for false as an empty string is a legal value.
         if (setting === false) {
-          throw new SyntaxError("An invalid or illegal string was specified.");
+          throw new SyntaxError("Scroll: an invalid or illegal scroll setting string was specified.");
         }
         _scroll = setting;
       }


### PR DESCRIPTION
Some of the error messages in vttcue.js and vttregion.js are generic, and don't specify which parameter has an invalid argument in the WebVTT file. This fixes those error messages.