### PR TITLE
Add parameter to processCues API to allow styling to be overridden.

### DIFF
--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -538,8 +538,8 @@ function CueStyleBox(window, cue, styleOptions) {
   // have inline positioning and will function as the cue background box.
   this.cueDiv = parseContent(window, cue.text);
   var styles = {
-    color: "rgba(255, 255, 255, 1)",
-    backgroundColor:  "rgba(0, 0, 0, 0.8)",
+    color: styleOptions.color || "inherit",
+    backgroundColor:  styleOptions.backgroundColor || "inherit",
     position: "relative",
     left: 0,
     right: 0,
@@ -565,7 +565,10 @@ function CueStyleBox(window, cue, styleOptions) {
                                                              : "vertical-rl",
     unicodeBidi: "plaintext",
     textAlign: cue.align === "middle" ? "center" : cue.align,
-    font: styleOptions.font,
+    font: styleOptions.font || "inherit",
+    fontVariant: styleOptions.fontVariant || "inherit",
+    textShadow: styleOptions.textShadow || "inherit",
+    backgroundColor: styleOptions.windowColor || "inherit",
     whiteSpace: "pre-line",
     position: "absolute"
   };
@@ -923,17 +926,22 @@ WebVTT.convertCueToDOMTree = function(window, cuetext) {
   return parseContent(window, cuetext);
 };
 
-var FONT_SIZE_PERCENT = 0.05;
-var FONT_STYLE = "sans-serif";
-var CUE_BACKGROUND_PADDING = "1.5%";
+var DEFAULT_FONT_SIZE_PERCENT = 5; // 5% of the height of the video window
+var DEFAULT_FONT_STYLE = "sans-serif";
+var DEFAULT_CUE_BACKGROUND_PADDING = "1.5%";
+var DEFAULT_FOREGROUND_COLOR = "rgba(255, 255, 255, 1)"; White, 100% opaque
+var DEFAULT_BACKGROUND_COLOR = "rgba(0, 0, 0, 0.8)"; Black, 80% opaque
+var DEFAULT_WINDOW_COLOR = "rgba(0, 0, 0, 0.0)"; Black, translucent
 
 // Runs the processing model over the cues and regions passed to it.
 // @param overlay A block level element (usually a div) that the computed cues
 //                and regions will be placed into.
-WebVTT.processCues = function(window, cues, overlay) {
+WebVTT.processCues = function(window, cues, overlay, styles) {
   if (!window || !cues || !overlay) {
     return null;
   }
+
+  styles = styles || {};
 
   // Remove all previous children.
   while (overlay.firstChild) {
@@ -946,7 +954,7 @@ WebVTT.processCues = function(window, cues, overlay) {
   paddedOverlay.style.right = "0";
   paddedOverlay.style.top = "0";
   paddedOverlay.style.bottom = "0";
-  paddedOverlay.style.margin = CUE_BACKGROUND_PADDING;
+  paddedOverlay.style.margin = styles.cueBackgroundMargin || DEFAULT_CUE_BACKGROUND_PADDING;
   overlay.appendChild(paddedOverlay);
 
   // Determine if we need to compute the display states of the cues. This could
@@ -971,10 +979,20 @@ WebVTT.processCues = function(window, cues, overlay) {
 
   var boxPositions = [],
       containerBox = BoxPosition.getSimpleBoxPosition(paddedOverlay),
-      fontSize = Math.round(containerBox.height * FONT_SIZE_PERCENT * 100) / 100;
+      fontSize = Math.round(containerBox.height * ((styles.fontSizePercent || 100.0) / 100.0) * DEFAULT_FONT_SIZE_PERCENT) / 100;
   var styleOptions = {
-    font: fontSize + "px " + FONT_STYLE
+    color: styles.color || DEFAULT_FOREGROUND_COLOR,
+    backgroundColor: styles.backgroundColor || DEFAULT_BACKGROUND_COLOR,
+    windowColor:  styles.windowColor || DEFAULT_WINDOW_COLOR,
+    font: fontSize + "px " + (styles.fontStyle || DEFAULT_FONT_STYLE)
   };
+
+  if (styles.fontVariant) {
+    styleOptions.fontVariant = styles.fontVariant;
+  }
+  if (styles.textShadow) {
+    styleOptions.textShadow = styles.textShadow;
+  }
 
   (function() {
     var styleBox, cue;


### PR DESCRIPTION
Similar to the [change in mozilla/vtt.js to allow external control of styling of the WebVTT cues](https://github.com/mozilla/vtt.js/commit/352982f6ad75e12f87b8e1f6e9fb3519f53021ec), add a parameter to the processCues API that allows video.js to pass its captions settings for video-vtt.js to implement them.

This PR supports all the styling options currently supported in video.js' `text-track-display.js`, while retaining backward compatibility with existing versions of video.js which haven't been changed to take advantage of this new parameter in the API.

Ultimately, moving the styling into video-vtt.js will allow for other customizations of Captions which are provided in other browsers but not currently available in video.js and video-vtt.js (e.g. not overriding any styling which is contained in the captions themselves), and also significantly simplify `text-track-display.js`.

This PR needs to add documentation for what parameters can be passed for styling, and to check for validity of parameters before using them.