### PR TITLE
Update to use align: center instead of middle for modern browsers

### DIFF
--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -191,21 +191,21 @@ function parseCue(input, cue, regionList) {
         settings.percent(k, vals0) ? settings.set("snapToLines", false) : null;
         settings.alt(k, vals0, ["auto"]);
         if (vals.length === 2) {
-          settings.alt("lineAlign", vals[1], ["start", "middle", "end"]);
+          settings.alt("lineAlign", vals[1], ["start", "center", "end"]);
         }
         break;
       case "position":
         vals = v.split(",");
         settings.percent(k, vals[0]);
         if (vals.length === 2) {
-          settings.alt("positionAlign", vals[1], ["start", "middle", "end"]);
+          settings.alt("positionAlign", vals[1], ["start", "center", "end"]);
         }
         break;
       case "size":
         settings.percent(k, v);
         break;
       case "align":
-        settings.alt(k, v, ["start", "middle", "end", "left", "right"]);
+        settings.alt(k, v, ["start", "center", "end", "left", "right"]);
         break;
       }
     }, /:/, /\s/);
@@ -217,10 +217,16 @@ function parseCue(input, cue, regionList) {
     cue.lineAlign = settings.get("lineAlign", "start");
     cue.snapToLines = settings.get("snapToLines", true);
     cue.size = settings.get("size", 100);
-    cue.align = settings.get("align", "middle");
+    // Safari still uses the old middle value and won't accept center
+    try {
+      cue.align = settings.get("align", "center");
+    } catch (e) {
+      cue.align = settings.get("align", "middle");
+    }
     cue.position = settings.get("position", {
       start: 0,
       left: 0,
+      center: 50,
       middle: 50,
       end: 100,
       right: 100
@@ -228,7 +234,8 @@ function parseCue(input, cue, regionList) {
     cue.positionAlign = settings.get("positionAlign", {
       start: "start",
       left: "start",
-      middle: "middle",
+      center: "center",
+      middle: "center",
       end: "end",
       right: "end"
     }, cue.align);
@@ -556,7 +563,7 @@ function CueStyleBox(window, cue, styleOptions) {
 
   // Create an absolutely positioned div that will be used to position the cue
   // div. Note, all WebVTT cue-setting alignments are equivalent to the CSS
-  // mirrors of them except "middle" which is "center" in CSS.
+  // mirrors of them except middle instead of center on Safari.
   this.div = window.document.createElement("div");
   styles = {
     direction: determineBidi(this.cueDiv),
@@ -581,7 +588,7 @@ function CueStyleBox(window, cue, styleOptions) {
   case "start":
     textPos = cue.position;
     break;
-  case "middle":
+  case "center":
     textPos = cue.position - (cue.size / 2);
     break;
   case "end":
@@ -859,7 +866,7 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions) {
     var calculatedPercentage = (boxPosition.lineHeight / containerBox.height) * 100;
 
     switch (cue.lineAlign) {
-    case "middle":
+    case "center":
       linePos -= (calculatedPercentage / 2);
       break;
     case "end":
@@ -1220,6 +1227,12 @@ WebVTT.Parser.prototype = {
             continue;
           }
           self.cue = new (self.vttjs.VTTCue || self.window.VTTCue)(0, 0, "");
+          // Safari still uses the old middle value and won't accept center
+          try {
+            self.cue.align = "center";
+          } catch (e) {
+            self.cue.align = "middle";
+          }
           self.state = "CUE";
           // 30-39 - Check if self line contains an optional identifier or timing data.
           if (line.indexOf("-->") === -1) {

--- a/lib/vttcue.js
+++ b/lib/vttcue.js
@@ -22,7 +22,7 @@ var directionSetting = {
 };
 var alignSetting = {
   "start": 1,
-  "middle": 1,
+  "center": 1,
   "end": 1,
   "left": 1,
   "right": 1
@@ -71,9 +71,9 @@ function VTTCue(startTime, endTime, text) {
   var _line = "auto";
   var _lineAlign = "start";
   var _position = 50;
-  var _positionAlign = "middle";
+  var _positionAlign = "center";
   var _size = 50;
-  var _align = "middle";
+  var _align = "center";
 
   Object.defineProperties(this, {
     "id": {


### PR DESCRIPTION
All of the major browsers implement a VTTCue object. Previously, Chrome's VTTCue implementation would accept an `align: middle` property, but more recent versions will complain that "middle" is not a valid enum. This matches the CSS/VTT spec for valid values. Therefore I have updated the code to represent centered cues with `align: center`. Safari still requires the old `align: middle` check, so the code has a fallback for that when setting `align = "center"` fails.

Fixes https://github.com/mozilla/vtt.js/issues/368