### PR TITLE
feat: add default text color and background color classes

### DIFF
--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -276,6 +276,19 @@ var TAG_NAME = {
   lang: "span"
 };
 
+// 5.1 default text color
+// 5.2 default text background color is equivalent to text color with bg_ prefix
+var DEFAULT_COLOR_CLASS = {
+  white: 'rgba(255,255,255,1)',
+  lime: 'rgba(0,255,0,1)',
+  cyan: 'rgba(0,255,255,1)',
+  red: 'rgba(255,0,0,1)',
+  yellow: 'rgba(255,255,0,1)',
+  magenta: 'rgba(255,0,255,1)',
+  blue: 'rgba(0,0,255,1)',
+  black: 'rgba(0,0,0,1)'
+};
+
 var TAG_ANNOTATION = {
   v: "title",
   lang: "lang"
@@ -378,7 +391,22 @@ function parseContent(window, input) {
       }
       // Set the class list (as a list of classes, separated by space).
       if (m[2]) {
-        node.className = m[2].substr(1).replace('.', ' ');
+        var classes = m[2].split('.');
+
+        classes.forEach(function(cl) {
+          var bgColor = /^bg_/.test(cl);
+          // slice out `bg_` if it's a background color
+          var colorName = bgColor ? cl.slice(3) : cl;
+
+          if (DEFAULT_COLOR_CLASS.hasOwnProperty(colorName)) {
+            var propName = bgColor ? 'background-color' : 'color';
+            var propValue = DEFAULT_COLOR_CLASS[colorName];
+
+            node.style[propName] = propValue;
+          }
+        });
+
+        node.className = classes.join(' ');
       }
       // Append the node to the current node, and enter the scope of the new
       // node.


### PR DESCRIPTION
This adds support for default style classes for vtt:
```
00:00:00.000 -> 00:00:05.000
<c.red.bg_green>This text is red with a green background
```
As per section 5 of the spec: https://www.w3.org/TR/webvtt1/#default-classes