### PR TITLE
fix: dont throw in vttregion for scroll setting

### DIFF
--- a/lib/vttregion.js
+++ b/lib/vttregion.js
@@ -123,9 +123,10 @@ function VTTRegion() {
         var setting = findScrollSetting(value);
         // Have to check for false as an empty string is a legal value.
         if (setting === false) {
-          throw new SyntaxError("Scroll: an invalid or illegal scroll setting string was specified.");
+          console.warn("Scroll: an invalid or illegal string was specified.");
+        } else {
+          _scroll = setting;
         }
-        _scroll = setting;
       }
     }
   });


### PR DESCRIPTION
Per spec, scroll setting doesn't throw.