### PR TITLE
Allow single digit timestamp values to be parsed

### DIFF
--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -58,7 +58,7 @@ function parseTimeStamp(input) {
     return (h | 0) * 3600 + (m | 0) * 60 + (s | 0) + (f | 0) / 1000;
   }
 
-  var m = input.match(/^(\d+):(\d{2})(:\d{2})?\.(\d{3})/);
+  var m = input.match(/^(\d+):(\d{1,2})(:\d{1,2})?\.(\d{3})/);
   if (!m) {
     return null;
   }


### PR DESCRIPTION
Our backend is serving timestamps in a technically invalid format, but one that is still supported (read: parsable) by Safari. I spoke to Gary offline and we think that in this case it makes sense to allow timestamps that contain single-digit values to be allowed by the vtt parser.

Example stream (try to play in Safari) - https://clientteststreams.streaming.mediaservices.windows.net/d308be31-bbbc-4647-86a2-603efe77de76/imsc1Test.ism/manifest(format=m3u8-aapl)

Regarding testing: The test suite for this lib is currently broken, so it was asked that I instead manually test. I confirmed that the following timestamps are parseable using the adjusted regex:

1. 000:00.000 --> 00:02.000 (all values contain at least two integers)
2. 68:41:3.567 --> 68:41:3.987 (some values contain only one integer)
