### PR TITLE
feat: improves unescape function

### DIFF
--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -271,14 +271,7 @@ function parseCue(input, cue, regionList) {
   consumeCueSettings(input, cue);
 }
 
-var ESCAPE = {
-  "&amp;": "&",
-  "&lt;": "<",
-  "&gt;": ">",
-  "&lrm;": "\u200e",
-  "&rlm;": "\u200f",
-  "&nbsp;": "\u00a0"
-};
+var TEXTAREA_ELEMENT = window.document.createElement("textarea");
 
 var TAG_NAME = {
   c: "span",
@@ -333,14 +326,10 @@ function parseContent(window, input) {
     return consume(m[1] ? m[1] : m[2]);
   }
 
-  // Unescape a string 's'.
-  function unescape1(e) {
-    return ESCAPE[e];
-  }
   function unescape(s) {
-    while ((m = s.match(/&(amp|lt|gt|lrm|rlm|nbsp);/))) {
-      s = s.replace(m[0], unescape1);
-    }
+    TEXTAREA_ELEMENT.innerHTML = s;
+    s = TEXTAREA_ELEMENT.textContent;
+    TEXTAREA_ELEMENT.textContent = "";
     return s;
   }
 


### PR DESCRIPTION
The library has a problem with showing some special HTML entities for example: `&deg;` .
To see the problem add some HTML entities inside the webvtt file.

> WEBVTT
>
>00:00:01.000 --> 00:00:15.000
>`&Aring;&aring;&Auml;&auml;&Ouml;&ouml;&AElig;&aelig;&Oslash;&oslash;`

The player will show `&Aring;&aring;&Auml;&auml;&Ouml;&ouml;&AElig;&aelig;&Oslash;&oslash;` insted of `ÅåÄäÖöÆæØø`.

I have fixed the problem using Textarea element to unescape this string. 