### PR TITLE
Allow including package in server side rendered Webpack bundle

### DIFF
--- a/lib/process/parse-content.js
+++ b/lib/process/parse-content.js
@@ -1,7 +1,9 @@
 var document = require('global/document');
 var parseTimeStamp = require('../parser/parse-timestamp.js');
 
-var TEXTAREA_ELEMENT = document.createElement("textarea");
+// When evaluating this file as part of a Webpack bundle for server
+// side rendering, `document` is an empty object.
+var TEXTAREA_ELEMENT = document.createElement && document.createElement("textarea");
 
 var NEEDS_PARENT = {
   rt: "ruby"


### PR DESCRIPTION
`videojs-vtt.js` relies on the `global` package to access browser
globals. When evaluated outside of a browser, for example in Node,
`global/document` falls back to a document object defined by the
`min-document` package [1].

Still, the `global` package instructs bundlers to ignore
`min-document` when building for the browser via the `browser` field
in its `package.json` [2].

This causes `require('global/document')` to return an empty object in
Webpack builds. When trying to use such a Webpack bundle for server
side rendering, `videojs-vtt.js` tries to call
`document.createElement` right when the bundle is first evaluated
which causes an exception.

All of the other browser specific functionality in the package does
not hurt since it is never executed (as long as no attempt is made to
parse VTT files during server side rendering).

To work around the problem, we only create the text area element if
`document.createElement` is defined. If it isn't, `parseContent` will
not work anyway.

[1] https://github.com/Raynos/global/blob/91c4362aa2720f7c7a3a085707de7e04f5e77cf3/document.js#L13
[2] https://github.com/Raynos/global/blob/91c4362aa2720f7c7a3a085707de7e04f5e77cf3/package.json#L20