### PR TITLE
Add numeric fallback value for line/position properties to Browsers that do not support the string "auto"

### DIFF
--- a/lib/parser/parse-cue.js
+++ b/lib/parser/parse-cue.js
@@ -66,7 +66,7 @@ function parseCue(input, cue, regionList) {
     cue.region = settings.get("region", null);
     cue.vertical = settings.get("vertical", "");
     try {
-      cue.line = settings.get("line", "auto");
+      cue.line = settings.get("line", -1);
     } catch (e) {
       // eslint-ignore-line
     }
@@ -80,7 +80,7 @@ function parseCue(input, cue, regionList) {
       cue.align = settings.get("align", "middle");
     }
     try {
-      cue.position = settings.get("position", "auto");
+      cue.position = settings.get("position", -1);
     } catch (e) {
       cue.position = settings.get("position", {
         start: 0,

--- a/lib/parser/parse-cue.js
+++ b/lib/parser/parse-cue.js
@@ -66,7 +66,9 @@ function parseCue(input, cue, regionList) {
     cue.region = settings.get("region", null);
     cue.vertical = settings.get("vertical", "");
     try {
-      cue.line = settings.get("line", -1);
+      cue.line = settings.get("line", "auto");
+      /** Set -1 as default value to contemplate scenarios where the Web Engine does not support the string auto and converts it to 0 */
+      if (settings.get("line") === undefined && cue.line != "auto") { cue.line = settings.get("line", -1) };
     } catch (e) {
       // eslint-ignore-line
     }
@@ -80,7 +82,9 @@ function parseCue(input, cue, regionList) {
       cue.align = settings.get("align", "middle");
     }
     try {
-      cue.position = settings.get("position", -1);
+      cue.position = settings.get("position", "auto");
+      /** Set -1 as default value to contemplate scenarios where the Web Engine does not support the string auto and converts it to 0 */
+      if (settings.get("position") === undefined && cue.line != "auto") { cue.position = settings.get("position", -1) };
     } catch (e) {
       cue.position = settings.get("position", {
         start: 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "videojs-vtt.js",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "videojs-vtt.js",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   ],
   "name": "videojs-vtt.js",
   "description": "A JavaScript implementation of the WebVTT specification, forked from vtt.js for use with Video.js",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "main": "lib/browser-index.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   ],
   "name": "videojs-vtt.js",
   "description": "A JavaScript implementation of the WebVTT specification, forked from vtt.js for use with Video.js",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "main": "lib/browser-index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Summary
This PR fixes the bug that happens on some TV Web Engines where the automatic value of line and position property `"auto"` is always converted to `0` because specifics browsers only support numeric values for both attributes. From now on will use the fallback value `-1` as fallback value since it's an equivalent of value `"auto"` and numeric having support on all Web Engines.

---

### Bug scenario

For example on [WeOS 3](https://webostv.developer.lge.com/discover/specifications/web-engine/) that uses `Chromium 38` as Web Engine this is what happens:

![image](https://user-images.githubusercontent.com/13765802/107417912-d00cdb00-6af4-11eb-9bf3-2070b73b1468.png)

When we attribute the value `auto` for `line` property it's converted to zero. If we check the `typeof cue.line` in these Browser the return is `numeric` but when the same command it's executed in newer browsers we can verify that returns `string`.

---

### Changes
- **parse-cue.js** - Check if the line/position property is undefined and the value is `0` after the attempt to set it to `auto` to use the fallback `-1`

