### PR TITLE
Trim parsed input group keys to remove whitespace

### DIFF
--- a/lib/parser/parse-options.js
+++ b/lib/parser/parse-options.js
@@ -11,7 +11,7 @@ function parseOptions(input, callback, keyValueDelim, groupDelim) {
       continue;
     }
     var k = kv[0].trim();
-    var v = kv[1];
+    var v = kv[1].trim();
     callback(k, v);
   }
 }

--- a/lib/parser/parse-options.js
+++ b/lib/parser/parse-options.js
@@ -10,7 +10,7 @@ function parseOptions(input, callback, keyValueDelim, groupDelim) {
     if (kv.length !== 2) {
       continue;
     }
-    var k = kv[0];
+    var k = kv[0].trim();
     var v = kv[1];
     callback(k, v);
   }


### PR DESCRIPTION
This PR introduces a minor adjustment to the keys parsed from each input group in `lib/parser/parseOptions.js`. This change will fix an issue first reported in videojs/http-streaming#982. 

Our video asset caption VTT files were generated in such a way that added an extra whitespace between the first group delimiter (`,`) and the key "LOCAL" (example below). This extra whitespace, while apparently in-compliance with the HLS-segmented VTT spec, causes VTT.js's parseOptions function to not properly parse cues from the VTT files, resulting in empty text tracks being attached to our player. 

## Example

WORKING:

```
X-TIMESTAMP-MAP=MPEGTS:187507,LOCAL:00:00:00.000
```

BROKEN:

```
X-TIMESTAMP-MAP=MPEGTS:187507, LOCAL:00:00:00.000
```