### PR TITLE
When calculating timestamps, account for mpegts rollover

### DIFF
--- a/lib/parser/parse-timestamp.js
+++ b/lib/parser/parse-timestamp.js
@@ -2,7 +2,9 @@
 function parseTimeStamp(input) {
 
   function computeSeconds(h, m, s, f) {
-    return (h | 0) * 3600 + (m | 0) * 60 + (s | 0) + (f | 0) / 1000;
+    var result = (h | 0) * 3600 + (m | 0) * 60 + (s | 0) + (f | 0) / 1000;
+    // account for mpegts rollover
+    return result % 95443;
   }
 
   var m = input.match(/^(\d+):(\d{1,2})(:\d{1,2})?\.(\d{3})/);


### PR DESCRIPTION
This fixes an issue with a long running stream where the cue start times are larger than the maximum mpegts timestamp of ~27 hours.