### PR TITLE
fix: Position align values

### DIFF
--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -614,12 +614,14 @@ function CueStyleBox(window, cue, styleOptions) {
   var textPos = 0;
   switch (cue.positionAlign) {
   case "start":
+  case "line-left":
     textPos = cue.position;
     break;
   case "center":
     textPos = cue.position - (cue.size / 2);
     break;
   case "end":
+  case "line-right":
     textPos = cue.position - cue.size;
     break;
   }


### PR DESCRIPTION
Adding additional values we allow for positioning for the `positionAlign` property. `line-left` and `line-right` are valid according to the [Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/API/VTTCue/positionAlign#value). However, without this, using one of the no longer values like "start" and "end" was fine in other browsers, but in Firefox, it would automatically change any value for `VTTCue.positionAlign` to `auto`, which we also do not account for here.

I figured the best solution was to ensure that we position the captions as expected when we receive these valid values for `positionAlign`.