### PR TITLE
Improve font size calculation for vertical video

### DIFF
--- a/lib/process/process-cues.js
+++ b/lib/process/process-cues.js
@@ -50,7 +50,7 @@ var processCues = function(window, cues, overlay) {
 
   var boxPositions = [],
       containerBox = BoxPosition.getSimpleBoxPosition(paddedOverlay),
-      fontSize = Math.round(containerBox.height * FONT_SIZE_PERCENT * 100) / 100;
+      fontSize = Math.round(Math.min(containerBox.width, containerBox.height) * FONT_SIZE_PERCENT * 100) / 100;
   var styleOptions = {
     font: fontSize + "px " + FONT_STYLE
   };


### PR DESCRIPTION
Otherwise subtitles on vertical videos become comically large.

Before / after:
<img width="30%" alt="image" src="https://github.com/user-attachments/assets/681c3978-b2d3-47a5-bbcb-7796bade8695" /> <img width="30%" alt="image" src="https://github.com/user-attachments/assets/52f4fa38-d1e7-41a4-9e89-53d2776f2fe9" />

Behavior on horizontal videos is unchanged.