### PR TITLE
Avoid infinite placement loop when lineHeight is 0

### DIFF
--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -820,9 +820,10 @@ function moveBoxToLinePosition(window, styleBox, containerBox, boxPositions) {
         percentage = 1; // Highest possible so the first thing we get is better.
 
     for (var i = 0; i < axis.length; i++) {
+      var step = b.lineHeight > 0 ? b.lineHeight : 1;
       while (b.overlapsOppositeAxis(containerBox, axis[i]) ||
              (b.within(containerBox) && b.overlapsAny(boxPositions))) {
-        b.move(axis[i]);
+        b.move(axis[i], step);
       }
       // We found a spot where we aren't overlapping anything. This is our
       // best position.


### PR DESCRIPTION
This can happen for empty subtitles.

---

Intuitively it makes more sense to me to ignore them earlier in the chain, but the tests expect it to exist there, which I suppose makes sense from a VTT parsing perspective.

https://github.com/videojs/vtt.js/blob/e9c8ae056c259226538b762e78d53c4c8871d643/tests/file-layout/cue-spacing.vtt#L8-L10

https://github.com/videojs/vtt.js/blob/e9c8ae056c259226538b762e78d53c4c8871d643/tests/file-layout/cue-spacing.json#L35-L50